### PR TITLE
Update oauth requirement from ~> 0.4.4 to >= 0.4.4, < 0.6.0

### DIFF
--- a/oauth-plugin.gemspec
+++ b/oauth-plugin.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack-test"
 
   s.add_dependency "multi_json"
-  s.add_dependency("oauth", ["~> 0.4.4"])
+  s.add_dependency("oauth", ">= 0.4.4", "< 0.6.0")
   s.add_dependency("rack")
   s.add_dependency("oauth2", '>= 0.5.0')
 end


### PR DESCRIPTION
Updates the requirements on oauth to permit the latest version.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>